### PR TITLE
 Filter support

### DIFF
--- a/src/components/BarHeader.vue
+++ b/src/components/BarHeader.vue
@@ -1,7 +1,7 @@
 <template>
   <div :class="Main">
     <div :class="barSidePanel">
-      <RouterLink to="/" class="titleDiv">
+      <RouterLink to="/" class="titleDiv" @click="isMobileClose()">
         <svg id="superdelta_img" width="26px" height="37px" viewBox="0 0 26 37" version="1.1"
           xmlns="http://www.w3.org/2000/svg">
           <g id="delta_logo" stroke-width="0.75" transform="translate(-19.000000, -14.000000)">
@@ -12,7 +12,7 @@
         </svg>
         <h1 v-if="barOpen">Zaiko</h1>
       </RouterLink>
-      <div class="navLinks">
+      <div class="navLinks" @click="isMobileClose()">
         <NavLink to="/search" title="Sök" :compact="!barOpen">
           <MagnifyingGlassIcon />
         </NavLink>
@@ -60,7 +60,14 @@ import NotificationList from '@/components/NotificationList.vue';
 import { useMediaQuery } from '@vueuse/core/index.cjs';
 
 const isMobile = useMediaQuery("(max-width: 768px)");
-const barOpen = ref<boolean>(!isMobile.value);
+const ShouldBarOpenStart = (): boolean => {
+  const isSmallScreen = useMediaQuery("(max-width: 1250px)");
+  if (isSmallScreen.value || isMobile.value) {
+    return false;
+  }
+  return true;
+}
+const barOpen = ref<boolean>(ShouldBarOpenStart());
 
 const barSidePanel = computed<string>(() => {
   return barOpen.value ? "barSidePanel" : "barSidePanel closed";
@@ -69,6 +76,12 @@ const barSidePanel = computed<string>(() => {
 const Main = computed<string>(() => {
   return barOpen.value ? "Main" : "Main MainClosed";
 });
+
+const isMobileClose = () => {
+  if (isMobile.value) {
+    barOpen.value = false;
+  }
+}
 
 </script>
 
@@ -87,8 +100,8 @@ const Main = computed<string>(() => {
 }
 
 .mainContent {
-  overflow: scroll;
   overflow-x: hidden;
+  overflow-y: scroll;
   background-color: #FAFAFA;
   border-top-left-radius: 16px;
   min-height: 100%;
@@ -169,7 +182,7 @@ a {
   height: 34px;
 }
 
-@media (max-width: 768px) {
+@media (max-width: 890px) {
   .Main {
     grid-template-columns: 210px 1fr;
   }
@@ -192,6 +205,16 @@ a {
 
   .barPanel {
     grid-template-rows: 56px 1fr;
+  }
+}
+
+@media only screen and (max-width: 768px) {
+  .Main {
+    overflow: hidden;
+  }
+
+  .MainClosed {
+    overflow: initial;
   }
 }
 </style>

--- a/src/components/BoxData.vue
+++ b/src/components/BoxData.vue
@@ -10,7 +10,7 @@ import { computed, defineProps } from 'vue'
 
 const props = defineProps({
   title: String,
-  amount: String,
+  amount: Number,
   good: Boolean,
 })
 

--- a/src/components/BoxData.vue
+++ b/src/components/BoxData.vue
@@ -50,4 +50,11 @@ h6 {
 .bad {
   background-color: #F6CDD6;
 }
+
+@media (max-width: 768px) {
+  div {
+    aspect-ratio: 1.2;
+  }
+
+}
 </style>

--- a/src/components/FilterPopup.vue
+++ b/src/components/FilterPopup.vue
@@ -16,12 +16,12 @@
         </div>
       </div>
       <div class="filterContent">
-        <button type="submit" class="filterSearch">
-          <MagnifyingGlassIcon />
-        </button>
-        <input type="text" placeholder="Filter" v-model="searchText" required />
         <button class="clearButton" @click="emit('clear')">
           <TrashIcon />
+        </button>
+        <input type="text" placeholder="Filter" v-model="searchText" required />
+        <button type="submit" class="filterSearch">
+          <MagnifyingGlassIcon />
         </button>
       </div>
     </form>

--- a/src/components/FilterPopup.vue
+++ b/src/components/FilterPopup.vue
@@ -4,14 +4,14 @@
       <FunnelIcon />
     </button>
     <form :class="filterClass + ' filterPanel'" v-if="isOpen"
-      @submit.prevent="emit('search', filterType[0], searchText)">
+      @submit.prevent="emit('search', filterType.name, searchText)">
       <div class="filterHeader">
         <FunnelIconSmall />
         <div class="colSelect">
-          <component :is="filterType[1]" />
+          <component :is="filterType.icon" />
           <select v-model="filterType" required>
-            <option :value="['Fält', NumberedListIcon]" selected disabled>Fält</option>
-            <option v-for="rec in columns" :key="rec[0]" :value="rec">{{ rec[0] }}</option>
+            <option :value="{ name: '', label: 'Fält', icon: NumberedListIcon }" selected disabled>Fält</option>
+            <option v-for="rec in columns" :key="rec.name" :value="rec">{{ rec.label }}</option>
           </select>
         </div>
       </div>
@@ -29,18 +29,19 @@
 </template>
 
 <script setup lang="ts">
-import { ref, computed, type FunctionalComponent } from 'vue';
+import { ref, computed } from 'vue';
 import { FunnelIcon, MagnifyingGlassIcon } from '@heroicons/vue/24/outline';
 import { FunnelIcon as FunnelIconSmall, NumberedListIcon, TrashIcon } from '@heroicons/vue/20/solid';
+import type { FilterColumn } from '@/types';
 
 const { columns } = defineProps<{
-  columns: Map<string, FunctionalComponent>;
+  columns: Array<FilterColumn>;
 }>()
 
 const emit = defineEmits(["search", "clear"]);
 
 const isOpen = ref(false);
-const filterType = ref<[string, FunctionalComponent]>(["Fält", NumberedListIcon]);
+const filterType = ref<FilterColumn>({ name: '', label: 'Fält', icon: NumberedListIcon });
 const searchText = ref();
 
 

--- a/src/components/FilterPopup.vue
+++ b/src/components/FilterPopup.vue
@@ -1,0 +1,167 @@
+<template>
+  <div class="filterContainer">
+    <button :class="filterClass" @click="isOpen = !isOpen">
+      <FunnelIcon />
+    </button>
+    <form :class="filterClass + ' filterPanel'" v-if="isOpen"
+      @submit.prevent="emit('search', filterType[0], searchText)">
+      <div class="filterHeader">
+        <FunnelIconSmall />
+        <div class="colSelect">
+          <component :is="filterType[1]" />
+          <select v-model="filterType" required>
+            <option :value="['Fält', NumberedListIcon]" selected disabled>Fält</option>
+            <option v-for="rec in columns" :key="rec[0]" :value="rec">{{ rec[0] }}</option>
+          </select>
+        </div>
+      </div>
+      <div class="filterContent">
+        <button type="submit" class="filterSearch">
+          <MagnifyingGlassIcon />
+        </button>
+        <input type="text" placeholder="Filter" v-model="searchText" required />
+        <button class="clearButton" @click="emit('clear')">
+          <TrashIcon />
+        </button>
+      </div>
+    </form>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { ref, computed, type FunctionalComponent } from 'vue';
+import { FunnelIcon, MagnifyingGlassIcon } from '@heroicons/vue/24/outline';
+import { FunnelIcon as FunnelIconSmall, NumberedListIcon, TrashIcon } from '@heroicons/vue/20/solid';
+
+const { columns } = defineProps<{
+  columns: Map<string, FunctionalComponent>;
+}>()
+
+const emit = defineEmits(["search", "clear"]);
+
+const isOpen = ref(false);
+const filterType = ref<[string, FunctionalComponent]>(["Fält", NumberedListIcon]);
+const searchText = ref();
+
+
+const filterClass = computed(() => {
+  return isOpen.value ? 'filterSelected' : '';
+});
+
+</script>
+
+<style scoped>
+button {
+  all: unset;
+  position: relative;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  padding: 0.4rem;
+  margin: 0;
+  border: none;
+  cursor: pointer;
+  background-color: #80CBC3;
+  border-radius: 8px;
+  color: #FAFAFA;
+  width: 32px;
+  height: 32px;
+}
+
+.filterSearch {
+  background-color: inherit;
+}
+
+.filterContainer {
+  position: relative;
+}
+
+.filterSelected {
+  box-shadow: 0 4px 4px rgba(0, 0, 0, 0.25);
+}
+
+.filterPanel {
+  border-radius: 8px;
+  position: absolute;
+  top: 3rem;
+  right: 0;
+  background-color: #FAFAFA;
+  width: 210px;
+  height: 100px;
+  z-index: 3;
+  padding: 0.66rem;
+}
+
+.filterHeader {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.filterHeader svg {
+  width: 21px;
+  height: 21px;
+  color: #DADADA;
+}
+
+.colSelect svg {
+  color: rgba(0, 0, 0, 0.33);
+
+}
+
+.colSelect {
+  display: flex;
+  align-items: center;
+  background-color: #DADADA;
+  padding: 0.4rem 0.5rem;
+  border-radius: 6px;
+}
+
+.colSelect select {
+  all: unset;
+  appearance: auto;
+  border-radius: 6px;
+  margin-left: 0.3rem;
+  min-width: 110px;
+}
+
+.filterContent {
+  display: grid;
+  grid-template-columns: 1fr 3fr 1fr;
+  align-items: center;
+  width: 100%;
+  padding: 0;
+  padding-top: 0.4rem;
+}
+
+.filterContent svg {
+  width: 24px;
+  height: 24px;
+  color: rgba(0, 0, 0, 0.33);
+}
+
+.filterContent input {
+  all: unset;
+  padding: 0.3rem;
+  border-radius: 0;
+  margin-left: 0.3rem;
+  max-width: 100px;
+}
+
+.filterContent button {
+  aspect-ratio: 1;
+  padding: 0.1rem;
+}
+
+.clearButton {
+  background-color: #F6CDD6;
+  aspect-ratio: 1;
+  padding: 0.1rem;
+}
+
+.clearButton svg {
+  color: #FAFAFA;
+  width: 24px;
+  height: 24px;
+}
+</style>

--- a/src/components/ItemForm.vue
+++ b/src/components/ItemForm.vue
@@ -73,11 +73,22 @@ import { useClubsStore } from '@/stores/clubs';
 import { useNotificationsStore } from '@/stores/notifications';
 const HOST = import.meta.env.VITE_HOST;
 
+const notificationsStore = useNotificationsStore();
 const clubStore = useClubsStore();
 
 const suppliers = ref<Array<SupplierListGetResponse>>([])
 
 const GetSuppliers = async () => {
+  if (clubStore.getClub() == "Nämnd") {
+    const noti: Notification = {
+      id: Date.now(),
+      title: "Warning",
+      message: "Nämnden har inga leverantörer",
+      severity: "warning",
+    }
+    notificationsStore.add(noti);
+    return;
+  };
   const url: string = HOST + "/api/" + clubStore.getClub() + "/suppliers";
   suppliers.value = await fetch(url, {
     method: "GET",
@@ -103,7 +114,6 @@ const supplier = ref<number>(-1)
 const link = ref<string>()
 
 const emit = defineEmits(["submit"]);
-const notificationsStore = useNotificationsStore();
 
 const addItem = async () => {
   const supplierId = supplier.value === -1 ? undefined : supplier.value;
@@ -116,6 +126,16 @@ const addItem = async () => {
     supplier: supplierId,
     link: link.value,
   }
+  if (clubStore.getClub() == "Nämnd") {
+    const noti: Notification = {
+      id: Date.now(),
+      title: "Error",
+      message: "Ingen nämnd vald",
+      severity: "error",
+    }
+    notificationsStore.add(noti);
+    return;
+  };
   const url: string = HOST + "/api/" + clubStore.getClub() + "/item";
   await fetch(url, {
     method: "POST",

--- a/src/components/ItemForm.vue
+++ b/src/components/ItemForm.vue
@@ -89,7 +89,7 @@ const GetSuppliers = async () => {
     notificationsStore.add(noti);
     return;
   };
-  const url: string = HOST + "/api/" + clubStore.getClub() + "/suppliers";
+  const url: string = HOST + "/api/" + clubStore.displayClub() + "/suppliers";
   suppliers.value = await fetch(url, {
     method: "GET",
   }).then((r) => r.json())
@@ -136,7 +136,7 @@ const addItem = async () => {
     notificationsStore.add(noti);
     return;
   };
-  const url: string = HOST + "/api/" + clubStore.getClub() + "/item";
+  const url: string = HOST + "/api/" + clubStore.displayClub() + "/item";
   await fetch(url, {
     method: "POST",
     body: JSON.stringify(res),

--- a/src/components/ItemForm.vue
+++ b/src/components/ItemForm.vue
@@ -131,13 +131,15 @@ const addItem = async () => {
         }
         notificationsStore.add(noti);
       } else {
-        const noti: Notification = {
-          id: Date.now(),
-          title: "Error",
-          message: "Något gick fel",
-          severity: "error",
-        }
-        notificationsStore.add(noti);
+        res.text().then((text) => {
+          const noti: Notification = {
+            id: Date.now(),
+            title: "Error",
+            message: text,
+            severity: "error",
+          }
+          notificationsStore.add(noti);
+        })
       }
     })
     .catch((error) => {

--- a/src/components/ItemForm.vue
+++ b/src/components/ItemForm.vue
@@ -106,13 +106,14 @@ const emit = defineEmits(["submit"]);
 const notificationsStore = useNotificationsStore();
 
 const addItem = async () => {
+  const supplierId = supplier.value === -1 ? undefined : supplier.value;
   const res: ItemAddRequest = {
     name: name.value,
     location: location.value,
     min: min.value,
     max: max.value,
     current: current.value,
-    supplier: supplier.value,
+    supplier: supplierId,
     link: link.value,
   }
   const url: string = HOST + "/api/" + clubStore.getClub() + "/item";

--- a/src/components/ItemPanel.vue
+++ b/src/components/ItemPanel.vue
@@ -88,6 +88,16 @@ const clubStore = useClubsStore();
 const suppliers = ref<Array<SupplierListGetResponse>>([])
 
 const GetSuppliers = () => {
+  if (clubStore.getClub() == "Nämnd") {
+    const noti: Notification = {
+      id: Date.now(),
+      title: "Error",
+      message: "Nämnd har ingen leverantör",
+      severity: "error",
+    }
+    notificationsStore.add(noti);
+    return;
+  };
   const url: string = HOST + "/api/" + clubStore.getClub() + "/suppliers";
   fetch(url, {
     method: "GET",

--- a/src/components/ItemPanel.vue
+++ b/src/components/ItemPanel.vue
@@ -143,13 +143,15 @@ const updateItem = async () => {
         }
         notificationsStore.add(noti);
       } else {
-        const noti: Notification = {
-          id: Date.now(),
-          title: "Error",
-          message: "Något gick fel",
-          severity: "error",
-        }
-        notificationsStore.add(noti);
+        res.text().then((text) => text).then((text) => {
+          const noti: Notification = {
+            id: Date.now(),
+            title: "Error",
+            message: text,
+            severity: "error",
+          }
+          notificationsStore.add(noti);
+        })
       }
     })
     .catch((error) => {
@@ -166,9 +168,9 @@ const updateItem = async () => {
 
 const Delete = async () => {
   const url: string = HOST + "/api/" + clubStore.getClub();
-  await fetch(url + "/item", {
+  const query = new URLSearchParams({ id: item.id.toString() }).toString();
+  await fetch(url + "/item?" + query, {
     method: "DELETE",
-    body: JSON.stringify({ name: name.value })
   })
     .then((res) => {
       if (res.ok) {
@@ -180,13 +182,15 @@ const Delete = async () => {
         }
         notificationsStore.add(noti);
       } else {
-        const noti: Notification = {
-          id: Date.now(),
-          title: "Error",
-          message: "Något gick fel",
-          severity: "error",
-        }
-        notificationsStore.add(noti);
+        res.text().then((text) => text).then((text) => {
+          const noti: Notification = {
+            id: Date.now(),
+            title: "Error",
+            message: text,
+            severity: "error",
+          }
+          notificationsStore.add(noti);
+        })
       }
     })
     .catch((error) => {

--- a/src/components/ItemPanel.vue
+++ b/src/components/ItemPanel.vue
@@ -98,7 +98,7 @@ const GetSuppliers = () => {
     notificationsStore.add(noti);
     return;
   };
-  const url: string = HOST + "/api/" + clubStore.getClub() + "/suppliers";
+  const url: string = HOST + "/api/" + clubStore.displayClub() + "/suppliers";
   fetch(url, {
     method: "GET",
   }).then((r) => r.json())
@@ -138,7 +138,7 @@ const updateItem = async () => {
     supplier: supplier.value,
     link: link.value,
   }
-  const url: string = HOST + "/api/" + clubStore.getClub();
+  const url: string = HOST + "/api/" + clubStore.displayClub();
   await fetch(url + "/item", {
     method: "PATCH",
     body: JSON.stringify(res),
@@ -177,7 +177,7 @@ const updateItem = async () => {
 }
 
 const Delete = async () => {
-  const url: string = HOST + "/api/" + clubStore.getClub();
+  const url: string = HOST + "/api/" + clubStore.displayClub();
   const query = new URLSearchParams({ id: item.id.toString() }).toString();
   await fetch(url + "/item?" + query, {
     method: "DELETE",

--- a/src/components/ItemsTable.vue
+++ b/src/components/ItemsTable.vue
@@ -122,7 +122,7 @@ GetSuppliers();
 
 <style scoped>
 table {
-  width: 85%;
+  width: calc(100% - 2rem);
   border-collapse: collapse;
   margin: 3rem 1rem;
 }

--- a/src/components/ItemsTable.vue
+++ b/src/components/ItemsTable.vue
@@ -101,7 +101,7 @@ const emit = defineEmits(['select'])
 
 const GetSuppliers = () => {
   if (clubStore.getClub() == "Nämnd") return;
-  const url: string = HOST + "/api/" + clubStore.getClub() + "/suppliers";
+  const url: string = HOST + "/api/" + clubStore.displayClub() + "/suppliers";
   fetch(url, {
     method: "GET",
   }).then((r) => r.json())

--- a/src/components/ItemsTable.vue
+++ b/src/components/ItemsTable.vue
@@ -100,6 +100,7 @@ const notificationsStore = useNotificationsStore()
 const emit = defineEmits(['select'])
 
 const GetSuppliers = () => {
+  if (clubStore.getClub() == "Nämnd") return;
   const url: string = HOST + "/api/" + clubStore.getClub() + "/suppliers";
   fetch(url, {
     method: "GET",

--- a/src/components/NotificationPopup.vue
+++ b/src/components/NotificationPopup.vue
@@ -51,7 +51,7 @@ const getColor = computed<string>(() => {
 const iconType = computed<number>(() => {
   switch (props.notification.severity) {
     case "info":
-      return 0;
+      return 3;
     case "warning":
       return 1;
     case "error":
@@ -99,7 +99,7 @@ svg {
 }
 
 .yellow {
-  color: #F8E720;
+  color: #b6b42e;
 }
 
 .red {

--- a/src/components/PanelTemplate.vue
+++ b/src/components/PanelTemplate.vue
@@ -1,12 +1,17 @@
 <template>
   <div class="panelContainer">
     <div class="panelHeader">
-      <TitleBig :title="title">
-        <slot name="icon" />
-      </TitleBig>
-      <button v-if="button" @click="emit('button')">
-        <PlusIcon />
-      </button>
+      <div class="headerLeft">
+        <TitleBig :title="title">
+          <slot name="icon" />
+        </TitleBig>
+        <button v-if="button" @click="emit('button')">
+          <PlusIcon />
+        </button>
+      </div>
+      <div class="headerRight">
+        <slot name="headerRight" />
+      </div>
     </div>
     <div class="panelContent">
       <slot name="content" />
@@ -30,7 +35,6 @@ button {
   align-items: center;
   padding: 0.4rem;
   margin: 0;
-  background-color: transparent;
   border: none;
   cursor: pointer;
   background-color: #80CBC3;
@@ -45,14 +49,30 @@ svg {
 
 .panelHeader {
   display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.headerLeft {
+  display: flex;
   justify-content: start;
   align-items: center;
-  gap: 1rem;
+}
+
+.headerRight {
+  display: flex;
+  justify-content: start;
+  align-items: center;
+  padding-right: 1rem;
 }
 
 @media (max-width: 768px) {
   .panelContainer {
     max-width: 100vw;
+  }
+
+  .headerRight {
+    padding-right: 0.5rem;
   }
 }
 </style>

--- a/src/components/ShortageTable.vue
+++ b/src/components/ShortageTable.vue
@@ -92,7 +92,7 @@ td {
   height: 20px;
 }
 
-@media (max-width: 768px) {
+@media (max-width: 1200px) {
   table {
     width: 100%;
     margin: 2rem 0;

--- a/src/components/StatsPanel.vue
+++ b/src/components/StatsPanel.vue
@@ -42,7 +42,7 @@ const notificationsStore = useNotificationsStore();
 const clubStore = useClubsStore();
 
 const GetData = () => {
-  const url: string = HOST + "/api/" + clubStore.getClub();
+  const url: string = HOST + "/api/" + clubStore.displayClub();
 
   fetch(url + "/stats")
     .then((res) => res.json())

--- a/src/components/StatsPanel.vue
+++ b/src/components/StatsPanel.vue
@@ -82,6 +82,10 @@ const totalSuppliers = ref<string>("WIP");
   .skip {
     grid-column: 2;
   }
+  .box {
+    margin-right: 0;
+    margin: 0;
+  }
   .box:nth-last-child(2) {
     grid-column: 1;
   }

--- a/src/components/StatsPanel.vue
+++ b/src/components/StatsPanel.vue
@@ -7,9 +7,9 @@
       <TitleMedium title="Leverantörer" class="skip">
         <ShoppingCartIcon />
       </TitleMedium>
-      <BoxData class="box" title="Totalt" :amount="total" good />
-      <BoxData class="box" title="Att köpa" :amount="toBuy" />
-      <BoxData class="box" title="Totalt" :amount="totalSuppliers" good />
+      <BoxData class="box" title="Totalt" :amount="stats.items" good />
+      <BoxData class="box" title="Att köpa" :amount="stats.shortages" />
+      <BoxData class="box" title="Totalt" :amount="stats.suppliers" good />
     </div>
     <div class="graphStats">
       <TitleMedium title="Total Mängd">
@@ -27,11 +27,38 @@ import TitleMedium from '@/components/TitleMedium.vue'
 import BoxData from '@/components/BoxData.vue'
 import { ArchiveBoxIcon, ShoppingCartIcon } from '@heroicons/vue/24/outline'
 import { ref } from 'vue';
+import { useNotificationsStore } from '@/stores/notifications'
+import { useClubsStore } from '@/stores/clubs';
+import type { Stats, Notification } from '@/types';
+const HOST = import.meta.env.VITE_HOST;
 
-const total = ref<string>("WIP");
-const toBuy = ref<string>("WIP");
-const totalSuppliers = ref<string>("WIP");
+const stats = ref<Stats>({
+  items: 0,
+  shortages: 0,
+  suppliers: 0.
+});
 
+const notificationsStore = useNotificationsStore();
+const clubStore = useClubsStore();
+
+const GetData = () => {
+  const url: string = HOST + "/api/" + clubStore.getClub();
+
+  fetch(url + "/stats")
+    .then((res) => res.json())
+    .then((json: Stats) => stats.value = json)
+    .catch((error) => {
+        const noti: Notification = {
+          id: Date.now(),
+          title: "Error",
+          message: error.toString(),
+          severity: "error",
+        }
+        notificationsStore.add(noti);
+    })
+}
+
+GetData();
 </script>
 
 <style scoped>

--- a/src/components/StockTable.vue
+++ b/src/components/StockTable.vue
@@ -114,6 +114,7 @@ const Filter = async () => {
 }
 
 const GetData = async () => {
+  if (clubStore.getClub() == "Nämnd") return;
   const url: string = HOST + "/api/" + clubStore.getClub();
   fetch(url + "/item")
     .then((res) => res.json())

--- a/src/components/StockTable.vue
+++ b/src/components/StockTable.vue
@@ -66,11 +66,15 @@
 
 <script setup lang="ts">
 import { ref } from 'vue'
-import type { ItemGetResponse, StockUpdateRequest, Notification } from '@/types'
+import type { ItemGetResponse, StockUpdateRequest, Notification, FilterItemParams } from '@/types'
 import { ArchiveBoxIcon, ShoppingCartIcon, HomeIcon, InboxArrowDownIcon, WalletIcon, ArrowsUpDownIcon, ClipboardDocumentListIcon } from '@heroicons/vue/16/solid'
 import { useNotificationsStore } from '@/stores/notifications'
 import { useClubsStore } from '@/stores/clubs'
 import { useMediaQuery } from '@vueuse/core/index.cjs'
+
+const { filter } = defineProps<{
+  filter: FilterItemParams | number
+}>()
 
 const isMobile = useMediaQuery('(max-width: 768px)');
 
@@ -88,6 +92,26 @@ const HOST: string = import.meta.env.VITE_HOST;
 
 const notificationsStore = useNotificationsStore();
 const clubStore = useClubsStore();
+
+const Filter = async () => {
+  const url: string = HOST + "/api/" + clubStore.getClub() + "/item?";
+  const params = new URLSearchParams(Object.entries(filter)).toString();
+  fetch(url + params)
+    .then((res) => res.json())
+    .then((json) => {
+      items.value = json
+      items.value.forEach((e: ItemGetResponse, idx) => input.value.items[idx] = [e.id, e.current])
+    })
+    .catch((error) => {
+      const noti: Notification = {
+        id: Date.now(),
+        title: "Error",
+        message: error.toString(),
+        severity: "error",
+      }
+      notificationsStore.add(noti);
+    })
+}
 
 const GetData = async () => {
   const url: string = HOST + "/api/" + clubStore.getClub();
@@ -107,7 +131,11 @@ const GetData = async () => {
       notificationsStore.add(noti);
     })
 }
-GetData();
+if (filter == 0) {
+  GetData()
+} else {
+  Filter()
+}
 
 const updateItems = async () => {
   const url: string = HOST + "/api/" + clubStore.getClub();
@@ -143,13 +171,17 @@ const updateItems = async () => {
       }
       notificationsStore.add(noti);
     })
-  GetData()
+  if (filter == 0) {
+    GetData()
+  } else {
+    Filter()
+  }
 }
 </script>
 
 <style scoped>
 table {
-  width: 85%;
+  width: calc(100% - 2rem);
   border-collapse: collapse;
   margin: 3rem 1rem;
 }

--- a/src/components/StockTable.vue
+++ b/src/components/StockTable.vue
@@ -94,7 +94,7 @@ const notificationsStore = useNotificationsStore();
 const clubStore = useClubsStore();
 
 const Filter = async () => {
-  const url: string = HOST + "/api/" + clubStore.getClub() + "/item?";
+  const url: string = HOST + "/api/" + clubStore.displayClub() + "/item?";
   const params = new URLSearchParams(Object.entries(filter)).toString();
   fetch(url + params)
     .then((res) => res.json())
@@ -115,7 +115,7 @@ const Filter = async () => {
 
 const GetData = async () => {
   if (clubStore.getClub() == "Nämnd") return;
-  const url: string = HOST + "/api/" + clubStore.getClub();
+  const url: string = HOST + "/api/" + clubStore.displayClub();
   fetch(url + "/item")
     .then((res) => res.json())
     .then((json) => {
@@ -139,7 +139,7 @@ if (filter == 0) {
 }
 
 const updateItems = async () => {
-  const url: string = HOST + "/api/" + clubStore.getClub();
+  const url: string = HOST + "/api/" + clubStore.displayClub();
   await fetch(url + "/stock", {
     method: "POST",
     body: JSON.stringify(input.value),

--- a/src/components/SupplierForm.vue
+++ b/src/components/SupplierForm.vue
@@ -66,7 +66,7 @@ const notificationsStore = useNotificationsStore();
 const clubStore = useClubsStore();
 
 const addSupplier = async () => {
-  const url: string = HOST + "/api/" + clubStore.getClub();
+  const url: string = HOST + "/api/" + clubStore.displayClub();
 
   const supplier: SupplierAddRequest = {
     name: name.value,

--- a/src/components/SupplierForm.vue
+++ b/src/components/SupplierForm.vue
@@ -75,6 +75,16 @@ const addSupplier = async () => {
     link: link.value,
     notes: note.value,
   }
+  if (clubStore.getClub() == "Nämnd") {
+    const noti: Notification = {
+      id: Date.now(),
+      title: "Error",
+      message: "Ingen nämnd vald",
+      severity: "error",
+    }
+    notificationsStore.add(noti);
+    return;
+  };
   await fetch(url + "/supplier", {
     method: "POST",
     body: JSON.stringify(supplier),

--- a/src/components/SupplierForm.vue
+++ b/src/components/SupplierForm.vue
@@ -89,13 +89,15 @@ const addSupplier = async () => {
         }
         notificationsStore.add(noti);
       } else {
-        const noti: Notification = {
-          id: Date.now(),
-          title: "Error",
-          message: "Något gick fel",
-          severity: "error",
-        }
-        notificationsStore.add(noti);
+        res.text().then((text) => {
+          const noti: Notification = {
+            id: Date.now(),
+            title: "Error",
+            message: text,
+            severity: "error",
+          }
+          notificationsStore.add(noti);
+        })
       }
     })
     .catch((error) => {

--- a/src/components/SupplierPanel.vue
+++ b/src/components/SupplierPanel.vue
@@ -41,7 +41,7 @@
           <DocumentCheckIcon class="buttonIcon" />
           <p>Spara</p>
         </button>
-        <button class="delete" @click.prevent="Delete" >
+        <button class="delete" @click.prevent="Delete">
           <BackspaceIcon class="buttonIcon" />
           <p>Radera</p>
         </button>
@@ -96,13 +96,15 @@ const updateSupplier = async () => {
         }
         notificationsStore.add(noti);
       } else {
-        const noti: Notification = {
-          id: Date.now(),
-          title: "Error",
-          message: "Något gick fel",
-          severity: "error",
-        }
-        notificationsStore.add(noti);
+        res.text().then((text) => {
+          const noti: Notification = {
+            id: Date.now(),
+            title: "Error",
+            message: text,
+            severity: "error",
+          }
+          notificationsStore.add(noti);
+        })
       }
     })
     .catch((error) => {
@@ -119,9 +121,10 @@ const updateSupplier = async () => {
 
 const Delete = async () => {
   const url: string = HOST + "/api/" + clubStore.getClub();
+  const query = new URLSearchParams({ id: item.id.toString() }).toString();
 
   await fetch(
-    url + "/supplier?" + new URLSearchParams({ id: item.id.toString() }).toString(),
+    url + "/supplier?" + query,
     {
       method: "DELETE",
     })
@@ -135,13 +138,15 @@ const Delete = async () => {
         }
         notificationsStore.add(noti);
       } else {
-        const noti: Notification = {
-          id: Date.now(),
-          title: "Error",
-          message: "Något gick fel",
-          severity: "error",
-        }
-        notificationsStore.add(noti);
+        res.text().then((text) => {
+          const noti: Notification = {
+            id: Date.now(),
+            title: "Error",
+            message: text,
+            severity: "error",
+          }
+          notificationsStore.add(noti);
+        })
       }
     })
     .catch((error) => {

--- a/src/components/SupplierPanel.vue
+++ b/src/components/SupplierPanel.vue
@@ -73,7 +73,7 @@ const link = ref(item.link)
 const note = ref(item.notes)
 
 const updateSupplier = async () => {
-  const url: string = HOST + "/api/" + clubStore.getClub();
+  const url: string = HOST + "/api/" + clubStore.displayClub();
   const supplier: SupplierUpdateRequest = {
     id: item.id,
     name: name.value,
@@ -120,7 +120,7 @@ const updateSupplier = async () => {
 }
 
 const Delete = async () => {
-  const url: string = HOST + "/api/" + clubStore.getClub();
+  const url: string = HOST + "/api/" + clubStore.displayClub();
   const query = new URLSearchParams({ id: item.id.toString() }).toString();
 
   await fetch(

--- a/src/components/SupplierTable.vue
+++ b/src/components/SupplierTable.vue
@@ -61,7 +61,7 @@ const isMobile = useMediaQuery('(max-width: 768px)');
 
 <style scoped>
 table {
-  width: 85%;
+  width: calc(100% - 2rem);
   border-collapse: collapse;
   margin: 3rem 1rem;
 }

--- a/src/components/TitleMedium.vue
+++ b/src/components/TitleMedium.vue
@@ -43,4 +43,12 @@ h2 {
   font-weight: semi-bold;
 }
 
+@media (max-width: 520px) {
+  .titleDiv {
+    margin: 0;
+    margin-bottom: 1rem;
+    padding: 0;
+  }
+}
+
 </style>

--- a/src/stores/clubs.ts
+++ b/src/stores/clubs.ts
@@ -61,10 +61,9 @@ export const useClubsStore = defineStore('clubs', () => {
   }
 
   function displayClub() {
-    if (clubs.value.club.length > 10) {
-      return clubs.value.club.substring(0, 9) + "...";
-    }
-    return clubs.value.club;
+    const club = getClub();
+    const displayClub = club.split("-")[0];
+    return displayClub;
   }
 
   return { clubs, setClub, getClub, displayClub }

--- a/src/stores/clubs.ts
+++ b/src/stores/clubs.ts
@@ -23,8 +23,19 @@ export const useClubsStore = defineStore('clubs', () => {
         if (clubs.value.clubs.length > 0) {
           clubs.value.timestamp = Date.now();
           clubs.value.club = clubs.value.clubs[0];
-          localStorage.setItem('clubs', JSON.stringify(clubs.value));
+        } else {
+          const noti: Notification = {
+            id: Date.now(),
+            title: "Nämnd",
+            message: "Ingen nämnd hittades",
+            severity: "error",
+          }
+          notificationsStore.add(noti);
+          clubs.value.club = "Nämnd";
+          clubs.value.clubs = ["Nämnd"];
+          clubs.value.timestamp = 0;
         }
+        localStorage.setItem('clubs', JSON.stringify(clubs.value));
       })
       .catch((error) => {
         const noti: Notification = {
@@ -43,7 +54,10 @@ export const useClubsStore = defineStore('clubs', () => {
   }
 
   function getClub() {
-    return clubs.value.club;
+    if (clubs.value.club === "") {
+      return "Nämnd";
+    }
+    return clubs.value.club ?? "Nämnd";
   }
 
   function displayClub() {

--- a/src/types.ts
+++ b/src/types.ts
@@ -32,6 +32,11 @@ export interface ItemUpdateRequest {
   link?: string,
 }
 
+export interface FilterItemParams {
+  column: string,
+  search: string,
+}
+
 export interface SupplierGetResponse {
   id: number,
   name: string,

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,3 +1,4 @@
+import type { FunctionalComponent } from 'vue';
 
 export interface ItemGetResponse {
   id: number,
@@ -30,6 +31,12 @@ export interface ItemUpdateRequest {
   current: number,
   supplier?: number,
   link?: string,
+}
+
+export interface FilterColumn {
+  name: string,
+  label: string,
+  icon: FunctionalComponent,
 }
 
 export interface FilterItemParams {

--- a/src/views/ItemsPage.vue
+++ b/src/views/ItemsPage.vue
@@ -68,6 +68,7 @@ const notificationsStore = useNotificationsStore();
 const clubStore = useClubsStore();
 
 const GetData = () => {
+  if (clubStore.getClub() == "Nämnd") return;
   UnSelect();
   const url: string = HOST + "/api/" + clubStore.getClub();
   fetch(url + "/item", {

--- a/src/views/ItemsPage.vue
+++ b/src/views/ItemsPage.vue
@@ -7,6 +7,9 @@
       <template #content>
         <ItemsTable :items="items" @select="SelectItem" />
       </template>
+      <template #headerRight>
+        <FilterPopup :columns="columns" @search="Filter" @clear="GetData()"/>
+      </template>
     </PanelTemplate>
     <PopupModal :modal="isModal" @exit="UnSelect()" :title="ModalTitle">
       <Suspense>
@@ -18,14 +21,16 @@
 </template>
 
 <script setup lang="ts">
-import { computed, ref } from 'vue';
-import type { ItemGetResponse, Notification } from '@/types';
+import { computed, ref, type FunctionalComponent } from 'vue';
+import type { ItemGetResponse, FilterItemParams, Notification } from '@/types';
 import PanelTemplate from '@/components/PanelTemplate.vue';
 import ItemsTable from '@/components/ItemsTable.vue';
 import PopupModal from '@/components/PopupModal.vue';
 import ItemForm from '@/components/ItemForm.vue';
+import FilterPopup from '@/components/FilterPopup.vue';
 import { ArchiveBoxIcon } from '@heroicons/vue/24/outline';
 import ItemPanel from '@/components/ItemPanel.vue';
+import { HomeIcon, ShoppingCartIcon, WalletIcon, Battery0Icon, Battery100Icon, InformationCircleIcon } from '@heroicons/vue/16/solid';
 import { useClubsStore } from '@/stores/clubs';
 import { useNotificationsStore } from '@/stores/notifications';
 const HOST = import.meta.env.VITE_HOST;
@@ -33,6 +38,16 @@ const HOST = import.meta.env.VITE_HOST;
 const items = ref<Array<ItemGetResponse>>([]);
 const isModal = ref<boolean>(false);
 const selected = ref<ItemGetResponse>();
+
+const columns: Map<string, FunctionalComponent> = new Map([
+  ['Produkt', ArchiveBoxIcon],
+  ['Plats', HomeIcon],
+  ['Leverantör', ShoppingCartIcon],
+  ['Mängd', WalletIcon],
+  ['Min', Battery0Icon],
+  ['Max', Battery100Icon],
+  ['Status', InformationCircleIcon],
+])
 
 const ModalTitle = computed(() => {
   return selected.value ? 'Redigera' : 'Lägg till';
@@ -70,6 +85,26 @@ const GetData = () => {
 }
 GetData()
 
+const Filter = (column: string, search: string) => {
+  const url: string = HOST + "/api/" + clubStore.getClub() + "/item?";
+  const query: FilterItemParams = {
+    column: column,
+    search: search,
+  }
+  const queryString = new URLSearchParams(Object.entries(query)).toString();
+  fetch(url + queryString, {
+    method: "GET",
+  }).then((r) => r.json()).then((r) => items.value = r)
+    .catch((error) => {
+      const noti: Notification = {
+        id: Date.now(),
+        title: "Error",
+        message: error.toString(),
+        severity: "error",
+      }
+      notificationsStore.add(noti);
+    })
+}
 </script>
 
 <style scoped>

--- a/src/views/ItemsPage.vue
+++ b/src/views/ItemsPage.vue
@@ -8,7 +8,7 @@
         <ItemsTable :items="items" @select="SelectItem" />
       </template>
       <template #headerRight>
-        <FilterPopup :columns="columns" @search="Filter" @clear="GetData()"/>
+        <FilterPopup :columns="columns" @search="Filter" @clear="GetData()" />
       </template>
     </PanelTemplate>
     <PopupModal :modal="isModal" @exit="UnSelect()" :title="ModalTitle">
@@ -21,8 +21,8 @@
 </template>
 
 <script setup lang="ts">
-import { computed, ref, type FunctionalComponent } from 'vue';
-import type { ItemGetResponse, FilterItemParams, Notification } from '@/types';
+import { computed, ref } from 'vue';
+import type { ItemGetResponse, FilterItemParams, Notification, FilterColumn } from '@/types';
 import PanelTemplate from '@/components/PanelTemplate.vue';
 import ItemsTable from '@/components/ItemsTable.vue';
 import PopupModal from '@/components/PopupModal.vue';
@@ -39,15 +39,15 @@ const items = ref<Array<ItemGetResponse>>([]);
 const isModal = ref<boolean>(false);
 const selected = ref<ItemGetResponse>();
 
-const columns: Map<string, FunctionalComponent> = new Map([
-  ['Produkt', ArchiveBoxIcon],
-  ['Plats', HomeIcon],
-  ['Leverantör', ShoppingCartIcon],
-  ['Mängd', WalletIcon],
-  ['Min', Battery0Icon],
-  ['Max', Battery100Icon],
-  ['Status', InformationCircleIcon],
-])
+const columns: Array<FilterColumn> = [
+  { name: 'product', label: 'Produkt', icon: ArchiveBoxIcon },
+  { name: 'location', label: 'Plats', icon: HomeIcon },
+  { name: 'supplier', label: 'Leverantör', icon: ShoppingCartIcon },
+  { name: 'amount', label: 'Mängd', icon: WalletIcon },
+  { name: 'min', label: 'Min', icon: Battery0Icon },
+  { name: 'max', label: 'Max', icon: Battery100Icon },
+  { name: 'status', label: 'Status', icon: InformationCircleIcon },
+];
 
 const ModalTitle = computed(() => {
   return selected.value ? 'Redigera' : 'Lägg till';

--- a/src/views/ItemsPage.vue
+++ b/src/views/ItemsPage.vue
@@ -68,6 +68,7 @@ const notificationsStore = useNotificationsStore();
 const clubStore = useClubsStore();
 
 const GetData = () => {
+  UnSelect();
   const url: string = HOST + "/api/" + clubStore.getClub();
   fetch(url + "/item", {
     method: "GET",

--- a/src/views/ItemsPage.vue
+++ b/src/views/ItemsPage.vue
@@ -70,7 +70,7 @@ const clubStore = useClubsStore();
 const GetData = () => {
   if (clubStore.getClub() == "Nämnd") return;
   UnSelect();
-  const url: string = HOST + "/api/" + clubStore.getClub();
+  const url: string = HOST + "/api/" + clubStore.displayClub();
   fetch(url + "/item", {
     method: "GET",
   }).then((r) => r.json()).then((r) => items.value = r)
@@ -88,7 +88,7 @@ const GetData = () => {
 GetData()
 
 const Filter = (column: string, search: string) => {
-  const url: string = HOST + "/api/" + clubStore.getClub() + "/item?";
+  const url: string = HOST + "/api/" + clubStore.displayClub() + "/item?";
   const query: FilterItemParams = {
     column: column,
     search: search,

--- a/src/views/MainPage.vue
+++ b/src/views/MainPage.vue
@@ -39,6 +39,7 @@ const notificationsStore = useNotificationsStore();
 const clubStore = useClubsStore();
 
 const GetData = () => {
+  if (clubStore.getClub() == "Nämnd") return;
   const url: string = HOST + "/api/" + clubStore.getClub();
 
   fetch(url + "/stock")

--- a/src/views/MainPage.vue
+++ b/src/views/MainPage.vue
@@ -67,7 +67,13 @@ GetData();
   padding-bottom: 0;
 }
 
-@media (max-width: 768px) {
+@media (max-width: 1150px) {
+  .main {
+    padding: 4rem 2rem;
+  }
+}
+
+@media (max-width: 1000px) {
   .main {
     grid-template-columns: 1fr;
     padding: 0.4rem;

--- a/src/views/MainPage.vue
+++ b/src/views/MainPage.vue
@@ -40,7 +40,7 @@ const clubStore = useClubsStore();
 
 const GetData = () => {
   if (clubStore.getClub() == "Nämnd") return;
-  const url: string = HOST + "/api/" + clubStore.getClub();
+  const url: string = HOST + "/api/" + clubStore.displayClub();
 
   fetch(url + "/stock")
     .then((res) => res.json())

--- a/src/views/StockPage.vue
+++ b/src/views/StockPage.vue
@@ -22,17 +22,17 @@ import StockTable from '@/components/StockTable.vue'
 import { ClipboardDocumentListIcon } from '@heroicons/vue/24/outline'
 import FilterPopup from '@/components/FilterPopup.vue'
 import { ArchiveBoxIcon, HomeIcon, ShoppingCartIcon, WalletIcon, InboxArrowDownIcon, ArrowsUpDownIcon } from '@heroicons/vue/16/solid'
-import type { FilterItemParams } from '@/types'
+import type { FilterColumn, FilterItemParams } from '@/types'
 import { computed, ref } from 'vue'
 
-const columns = new Map([
-  ['Produkt', ArchiveBoxIcon],
-  ['Plats', HomeIcon],
-  ['Leverantör', ShoppingCartIcon],
-  ['Mängd', WalletIcon],
-  ['Nya', InboxArrowDownIcon],
-  ['Differens', ArrowsUpDownIcon],
-])
+const columns: Array<FilterColumn> = [
+  { name: 'product', label: 'Produkt', icon: ArchiveBoxIcon },
+  { name: 'location', label: 'Plats', icon: HomeIcon },
+  { name: 'supplier', label: 'Leverantör', icon: ShoppingCartIcon },
+  { name: 'quantity', label: 'Mängd', icon: WalletIcon },
+  { name: 'new', label: 'Nya', icon: InboxArrowDownIcon },
+  { name: 'difference', label: 'Differens', icon: ArrowsUpDownIcon },
+];
 
 const filter = ref<FilterItemParams | number>(0);
 

--- a/src/views/StockPage.vue
+++ b/src/views/StockPage.vue
@@ -6,8 +6,11 @@
       </template>
       <template #content>
         <Suspense>
-          <StockTable />
+          <StockTable :filter="filter" :key="key" />
         </Suspense>
+      </template>
+      <template #headerRight>
+        <FilterPopup :columns="columns" @search="Filter" @clear="Clear()" />
       </template>
     </PanelTemplate>
   </div>
@@ -17,6 +20,36 @@
 import PanelTemplate from '@/components/PanelTemplate.vue'
 import StockTable from '@/components/StockTable.vue'
 import { ClipboardDocumentListIcon } from '@heroicons/vue/24/outline'
+import FilterPopup from '@/components/FilterPopup.vue'
+import { ArchiveBoxIcon, HomeIcon, ShoppingCartIcon, WalletIcon, InboxArrowDownIcon, ArrowsUpDownIcon } from '@heroicons/vue/16/solid'
+import type { FilterItemParams } from '@/types'
+import { computed, ref } from 'vue'
+
+const columns = new Map([
+  ['Produkt', ArchiveBoxIcon],
+  ['Plats', HomeIcon],
+  ['Leverantör', ShoppingCartIcon],
+  ['Mängd', WalletIcon],
+  ['Nya', InboxArrowDownIcon],
+  ['Differens', ArrowsUpDownIcon],
+])
+
+const filter = ref<FilterItemParams | number>(0);
+
+const Filter = (column: string, search: string) => {
+  filter.value = { column, search }
+}
+const Clear = () => {
+  filter.value = 0
+}
+
+const key = computed(() => {
+  if (typeof filter.value === 'number') {
+    return filter.value
+  }
+  return filter.value.column + filter.value.search
+})
+
 </script>
 
 <style scoped>

--- a/src/views/SupplierPage.vue
+++ b/src/views/SupplierPage.vue
@@ -26,7 +26,7 @@ import PopupModal from '@/components/PopupModal.vue';
 import SupplierForm from '@/components/SupplierForm.vue';
 import { ShoppingCartIcon } from '@heroicons/vue/24/outline';
 import SupplierPanel from '@/components/SupplierPanel.vue';
-import type { SupplierGetResponse, Notification, FilterItemParams } from '@/types';
+import type { SupplierGetResponse, Notification, FilterItemParams, FilterColumn } from '@/types';
 import { useNotificationsStore } from '@/stores/notifications';
 import { useClubsStore } from '@/stores/clubs';
 import { ShoppingCartIcon as ShoppingCartIconSmall, UserCircleIcon, LockClosedIcon, DocumentTextIcon } from '@heroicons/vue/16/solid';
@@ -42,12 +42,12 @@ const ModalTitle = computed(() => {
   return selected.value ? 'Redigera' : 'Lägg till';
 })
 
-const columns = new Map([
-  ['Namn', ShoppingCartIconSmall],
-  ['Användarnamn', UserCircleIcon],
-  ['Lösenord', LockClosedIcon],
-  ['Anteckningar', DocumentTextIcon],
-])
+const columns: Array<FilterColumn> = [
+  { name: 'name', label: 'Namn', icon: ShoppingCartIconSmall },
+  { name: 'username', label: 'Användarnamn', icon: UserCircleIcon },
+  { name: 'password', label: 'Lösenord', icon: LockClosedIcon },
+  { name: 'notes', label: 'Anteckningar', icon: DocumentTextIcon },
+];
 
 const UnSelect = () => {
   selected.value = undefined

--- a/src/views/SupplierPage.vue
+++ b/src/views/SupplierPage.vue
@@ -63,6 +63,7 @@ const notificationsStore = useNotificationsStore();
 const clubStore = useClubsStore();
 
 const GetData = () => {
+  if (clubStore.getClub() == "Nämnd") return;
   UnSelect();
   const url: string = HOST + "/api/" + clubStore.getClub();
 

--- a/src/views/SupplierPage.vue
+++ b/src/views/SupplierPage.vue
@@ -65,7 +65,7 @@ const clubStore = useClubsStore();
 const GetData = () => {
   if (clubStore.getClub() == "Nämnd") return;
   UnSelect();
-  const url: string = HOST + "/api/" + clubStore.getClub();
+  const url: string = HOST + "/api/" + clubStore.displayClub();
 
   fetch(url + "/supplier", {
     method: "GET",
@@ -85,7 +85,7 @@ const GetData = () => {
 GetData();
 
 const Filter = (column: string, search: string) => {
-  const url: string = HOST + "/api/" + clubStore.getClub() + "/supplier?";
+  const url: string = HOST + "/api/" + clubStore.displayClub() + "/supplier?";
   const query: FilterItemParams = {
     column: column,
     search: search,

--- a/src/views/SupplierPage.vue
+++ b/src/views/SupplierPage.vue
@@ -63,6 +63,7 @@ const notificationsStore = useNotificationsStore();
 const clubStore = useClubsStore();
 
 const GetData = () => {
+  UnSelect();
   const url: string = HOST + "/api/" + clubStore.getClub();
 
   fetch(url + "/supplier", {

--- a/src/views/SupplierPage.vue
+++ b/src/views/SupplierPage.vue
@@ -7,6 +7,9 @@
       <template #content>
         <SupplierTable :items="suppliers" @select="SelectItem" />
       </template>
+      <template #headerRight>
+        <FilterPopup :columns="columns" @search="Filter" @clear="GetData()"/>
+      </template>
     </PanelTemplate>
     <PopupModal :modal="isModal" @exit="UnSelect()" :title="ModalTitle">
       <SupplierPanel v-if="selected" :item="selected" @submit="GetData()" @delete="GetData()"/>
@@ -23,9 +26,11 @@ import PopupModal from '@/components/PopupModal.vue';
 import SupplierForm from '@/components/SupplierForm.vue';
 import { ShoppingCartIcon } from '@heroicons/vue/24/outline';
 import SupplierPanel from '@/components/SupplierPanel.vue';
-import type { SupplierGetResponse, Notification } from '@/types';
+import type { SupplierGetResponse, Notification, FilterItemParams } from '@/types';
 import { useNotificationsStore } from '@/stores/notifications';
 import { useClubsStore } from '@/stores/clubs';
+import { ShoppingCartIcon as ShoppingCartIconSmall, UserCircleIcon, LockClosedIcon, DocumentTextIcon } from '@heroicons/vue/16/solid';
+import FilterPopup from '@/components/FilterPopup.vue';
 
 const HOST = import.meta.env.VITE_HOST;
 
@@ -36,6 +41,13 @@ const selected = ref<SupplierGetResponse>();
 const ModalTitle = computed(() => {
   return selected.value ? 'Redigera' : 'Lägg till';
 })
+
+const columns = new Map([
+  ['Namn', ShoppingCartIconSmall],
+  ['Användarnamn', UserCircleIcon],
+  ['Lösenord', LockClosedIcon],
+  ['Anteckningar', DocumentTextIcon],
+])
 
 const UnSelect = () => {
   selected.value = undefined
@@ -70,6 +82,26 @@ const GetData = () => {
 }
 GetData();
 
+const Filter = (column: string, search: string) => {
+  const url: string = HOST + "/api/" + clubStore.getClub() + "/supplier?";
+  const query: FilterItemParams = {
+    column: column,
+    search: search,
+  }
+  const queryString = new URLSearchParams(Object.entries(query)).toString();
+  fetch(url + queryString, {
+    method: "GET",
+  }).then((r) => r.json()).then((r) => suppliers.value = r)
+    .catch((error) => {
+      const noti: Notification = {
+        id: Date.now(),
+        title: "Error",
+        message: error.toString(),
+        severity: "error",
+      }
+      notificationsStore.add(noti);
+    })
+}
 </script>
 
 <style scoped>


### PR DESCRIPTION
Added a button to filter based on each column in table.
Filtering is done through backend api based on this new api draft:

Query params: 
- `column`: column in data table
- `search`: text string to match

To GET endpoint, i.e; `/item` and `/supplier`

For example: `/item?column=product&search=Tejp`

Fixes: #8 